### PR TITLE
WASA-SED applicaiton Ceará set-up

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -2198,7 +2198,7 @@ Neitsch, S.L., Arnold, J.G., Kiniry, J.R., Williams, J.R., King, K.W. (2002): So
 Pilz, T., T. Francke, & A. Bronstert (2017): lumpR: An R package facilitating landscape discretisation for hillslope-based hydrological models, Geosci Model Dev, 10(8), 3001–3023, doi:https://doi.org/10.5194/gmd-10-3001-2017.
 
 <a name="rottler-2017"></a>
-Rottler, E. (2017): Implementation of a snow routine into the hydrological model WASA-SED and its validation in a mountainous catchment. MSc Thesis, University Potsdam, Germany. To be published on https://publishup.uni-potsdam.de/opus4-ubp/home).
+Rottler, E. (2017): Implementation of a snow routine into the hydrological model WASA-SED and its validation in a mountainous catchment. MSc Thesis, University Potsdam, Germany. https://doi.org/10.25932/publishup-50496.
 
 <a name="williams-1995"></a>
 Williams, J. (1995): The EPIC Model. In: Singh, V. P. (Eds.): Computer Models of Watershed Hydrology. Water Resources Publications, Highlands Ranch, CO., pp. 909-1000.

--- a/src/Hillslope/model_state_io.f90
+++ b/src/Hillslope/model_state_io.f90
@@ -432,7 +432,7 @@ contains
             DO sb_counter=1,subasin
                 DO acud_class=1,5
 				    if (lake_file_hdle/=0) then
-					    WRITE(lake_file_hdle,'(I0,A1,I0,A1,F11.2)') id_subbas_extern(sb_counter), char(9),acud_class,char(9),&
+					    WRITE(lake_file_hdle,'(I0,A1,I0,A1,F13.2)') id_subbas_extern(sb_counter), char(9),acud_class,char(9),&
 						    lakewater_hrr(tt,sb_counter,acud_class)
 				    endif
 				    total_storage_lake(acud_class) = total_storage_lake(acud_class)+lakewater_hrr(tt,sb_counter,acud_class) * acud(sb_counter,acud_class) !sum up total storage


### PR DESCRIPTION
To run WASA-SED for the entire state of Ceará minor modifications where required, i.e. extend string of storage volume reservoir classes. 